### PR TITLE
feat: validate absolute internal module paths as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.0](https://github.com/lokalise/eslint-plugin/compare/v1.3.1...v1.4.0) (2022-09-23)
+
+
+### Features
+
+* validate absolute internal module paths as well ([9a0de4e](https://github.com/lokalise/eslint-plugin/commit/9a0de4e9b197e63632d664e82e0f22bf162c45c3))
+
 ### [1.3.1](https://github.com/lokalise/eslint-plugin/compare/v1.3.0...v1.3.1) (2022-05-31)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lokalise/eslint-plugin",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lokalise/eslint-plugin",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "eslint-module-utils": "^2.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lokalise/eslint-plugin",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "ESLint plugin for Lokalise",
   "main": "index.js",
   "author": "Lokalise",

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -84,5 +84,16 @@ ruleTester.run('package-boundary', rule, {
                 },
             ],
         }),
+        test({
+            code: `import "a-module/sub-a-module/index.js"`,
+            filename: testFilePath('./package-boundary/a-module/file.js'),
+            errors: [
+                {
+                    message: 'Passing module boundary. Should import from `a-module`.',
+                    line: 1,
+                    column: 8,
+                },
+            ],
+        }),
     ],
 });

--- a/utils.js
+++ b/utils.js
@@ -6,6 +6,8 @@ export function testFilePath(relativePath) {
 
 const FILENAME = testFilePath('foo.js');
 
+const packageDir = __dirname;
+
 export function test(t) {
     if (arguments.length !== 1) {
         throw new SyntaxError('`test` requires exactly one object argument');
@@ -24,6 +26,17 @@ export function test(t) {
                 },
                 t.parserOptions,
             ),
+            settings: {
+                'import/internal-regex': /^\w-module/,
+                'import/resolver': {
+                    'node': {
+                        paths: [
+                            path.join(packageDir, '__fixtures__', 'files', 'package-boundary'),
+                            path.join(packageDir, 'node_modules'),
+                        ],
+                    },
+                },
+            },
         },
     );
 }


### PR DESCRIPTION
Finally we'll start validating also absolute import paths for boundaries. No longer paths like `@app/features/project/some/deep/path` will be allowed.